### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ language: julia
 before_install:
   - sudo apt-get install python-networkx
 julia:
-  - release
   - 0.4
+  - 0.5


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.4 so it should continue to be tested